### PR TITLE
Add various optional confluent services, helper script for kafka CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,32 @@ $ kafkacat -C -b kc1.docker -t top1 -c 1
 Hello Kafka
 
 # Rafka
-$ redis-cli -p 6380 rpushx topics:top1 "hello there"
+$ redis-cli -h rafka.docker -p 6380 rpushx topics:top1 "hello there"
 
 # Remove everything
 $ docker-compose down
+```
+
+# Additional services
+
+Additional kafka-related services are available
+
+* [Rafka](https://github.com/skroutz/rafka)
+* [Schema Registry](https://github.com/confluentinc/schema-registry)
+* [Kafka REST](https://github.com/confluentinc/kafka-rest)
+* [KSQL](https://github.com/confluentinc/ksql)
+* [Confluent Control Center](https://docs.confluent.io/current/control-center/docs/index.html)
+
+These services are not started by default and defined in `docker-compose.additional.yml`, according to the
+[Multiple Compose files pattern](https://docs.docker.com/compose/extends/#multiple-compose-files)
+and can be started independently through
+
+```sh
+docker-compose -f docker-compose.additional.yml up
+```
+
+All services, both kafka and all the additional ones, can be started through
+
+```sh
+docker-compose -f docker-compose.yml -f docker-compose.additional.yml up
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ $ docker-compose build
 $ docker-compose up (Ctrl-C to stop)
 
 # Create a new topic
-$ docker-compose exec kc1.docker kafka-topics --zookeeper zoo1,zoo2 --topic top1 --partitions 2 --replication-factor 2 --create
-top1
-$ docker-compose exec kc1.docker kafka-topics --zookeeper zoo1,zoo2 --describe
+$ ./k.sh topics --topic top1 --partitions 2 --replication-factor 2 --create
+$ ./k.sh topics --describe
 Topic:top1	PartitionCount:2	ReplicationFactor:2	Configs:
 	Topic: top1	Partition: 0	Leader: 1	Replicas: 1,2	Isr: 1,2
 	Topic: top1	Partition: 1	Leader: 2	Replicas: 2,1	Isr: 2,1

--- a/docker-compose.additional.yml
+++ b/docker-compose.additional.yml
@@ -1,0 +1,52 @@
+version: '2'
+services:
+  rafka:
+    build:
+      context: ./rafka
+    hostname: rafka
+    container_name: rafka
+    restart: unless-stopped
+    env_file: ./.env
+  ksql:
+    build:
+      context: ./ksql
+    hostname: ksql
+    container_name: ksql
+    restart: unless-stopped
+  schema-registry:
+    image: "confluentinc/cp-schema-registry:5.0.0"
+    hostname: schema-registry
+    container_name: schema-registry
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zoo1:2181
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+  kafka-rest:
+    image: "confluentinc/cp-kafka-rest:5.0.0"
+    hostname: kafka-rest
+    container_name: kafka-rest
+    environment:
+      KAFKA_REST_ZOOKEEPER_CONNECT: zoo1:2181
+      KAFKA_REST_LISTENERS: http://0.0.0.0:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      KAFKA_REST_HOST_NAME: kafka-rest
+  control-center:
+    image: "confluentinc/cp-enterprise-control-center:5.0.0"
+    hostname: control-center
+    container_name: control-center
+    ulimits:
+      nofile:
+        soft: 16384
+        hard: 16384
+#    volumes:
+#     - /tmp/control-center/data:/var/lib/confluent-control-center
+    environment:
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: zoo1:2181
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: kc1.docker:9092,kc2.docker:9092
+      CONTROL_CENTER_KSQL_URL: http://ksql:8088
+      CONTROL_CENTER_SCHEMA_REGISTRY_URL: http://schema_registry:8081
+      CONTROL_CENTER_CONNECT_CLUSTER: kc1.docker:9092,kc2.docker:9092
+      CONTROL_CENTER_REPLICATION_FACTOR: 2
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 2
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 2
+      CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,3 @@ services:
     env_file: ./.env
     environment:
       KAFKA_BROKER_ID: 2
-  rafka:
-    build:
-      context: ./rafka
-    ports:
-      - "6380:6380"
-    hostname: rafka
-    restart: unless-stopped
-    env_file: ./.env

--- a/k.sh
+++ b/k.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Adapted from https://github.com/wikimedia/puppet/blob/5b4d5817b2ec0fb3c7938c286640fa6924563823/modules/confluent/files/kafka/kafka.sh.
+
+SCRIPT_NAME=$(basename "$0")
+KAFKA_ZOOKEEPER_URL="${ZOOKEEPER_URL:=zoo1,zoo2,zoo3}"
+KAFKA_BOOTSTRAP_SERVERS="${BROKER_LIST:=kc1.docker:9092,kc2.docker:9092}"
+docker_exec="docker-compose exec kc1.docker"
+
+commands=$(${docker_exec} ls /usr/bin/kafka-* | xargs -n 1 basename | sed 's@kafka-@  @g')
+
+USAGE="
+$SCRIPT_NAME <command> [options]
+
+Handy wrapper around various kafka-* scripts.  Set the environment variables
+KAFKA_ZOOKEEPER_URL, KAFKA_BOOTSTRAP_SERVERS so you don't have to keep typing
+--zookeeper-connect, --broker-list or --bootstrap-server each time you want to
+use a kafka-* script.
+
+Usage:
+
+Run $SCRIPT_NAME <command> with zero arguments/options to see command usage.
+
+Commands:
+$commands
+
+Environment Variables:
+  KAFKA_JAVA_HOME         - Value of JAVA_HOME to use for invoking Kafka commands.
+  KAFKA_ZOOKEEPER_URL     - If this is set, any commands that take a --zookeeper
+                            flag will be given this value.
+  KAFKA_BOOTSTRAP_SERVERS - If this is set, any commands that take a --broker-list or
+                            --bootstrap-server flag will be given this value.
+                            Also any command that take a --authorizer-properties
+                            will get the correct zookeeper.connect value.
+
+"
+
+# Print usage if no <command> given, or $1 starts with '-'
+if [ -z "${1}" -o "${1:0:1}" == '-' ]; then
+    echo "${USAGE}"
+    exit 1
+fi
+
+# All kafka scripts start with kafka-.
+command="kafka-${1}"
+shift
+
+# Export JAVA_HOME as KAFKA_JAVA_HOME if it is set.
+# This makes kafka-run-class use the preferred JAVA_HOME for Kafka.
+if [ -n "${KAFKA_JAVA_HOME}" ]; then
+    : ${JAVA_HOME="$KAFKA_JAVA_HOME"}
+    export JAVA_HOME
+fi
+
+# Set ZOOKEEPER_OPT if ZOOKEEPER_URL is set and --zookeeper has not
+# also been passed in as a CLI arg.  This will be included
+# in command functions that take a --zookeeper argument.
+if [ -n "${KAFKA_ZOOKEEPER_URL}" -a -z "$(echo $@ | grep -- --zookeeper)" ]; then
+    ZOOKEEPER_OPT="--zookeeper ${KAFKA_ZOOKEEPER_URL}"
+fi
+
+# Set BROKER_LIST_OPT if KAFKA_BOOTSTRAP_SERVERS is set and --broker-list has not
+# also been passed in as a CLI arg.  This will be included
+# in command functions that take a --broker-list argument.
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS}" -a -z "$(echo $@ | grep -- --broker-list)" ]; then
+    BROKER_LIST_OPT="--broker-list ${KAFKA_BOOTSTRAP_SERVERS}"
+fi
+
+# Set BOOTSTRAP_SERVER_OPT if KAFKA_BOOTSTRAP_SERVERS is set and --bootstrap-server has not
+# also been passed in as a CLI arg.  This will be included
+# in command functions that take a --bootstrap-server argument.
+if [ -n "${KAFKA_BOOTSTRAP_SERVERS}" -a -z "$(echo $@ | grep -- --bootstrap-server)" ]; then
+    BOOTSTRAP_SERVER_OPT="--bootstrap-server ${KAFKA_BOOTSTRAP_SERVERS}"
+fi
+
+# Set ZOOKEEPER_CONNECT_OPT if KAFKA_ZOOKEEPER_URL is set and '--authorizer-properties zookeeper.connect'
+# has not also been passed in as a CLI arg.  This will be included
+# in command functions that take '--authorizer-properties zookeeper.connect' argument.
+if [ -n "${KAFKA_ZOOKEEPER_URL}" -a -z "$(echo $@ | egrep -- '--authorizer-properties\ *zookeeper\.connect')" ]; then
+    ZOOKEEPER_CONNECT_OPT="--authorizer-properties zookeeper.connect=${KAFKA_ZOOKEEPER_URL}"
+fi
+
+# Each of these lists signifies that either --broker-list, --bootstrap-server,
+# or --zookeeper needs to be given to the $command.  If $command matches one of these,
+# then we will add the opt if it is not provided already in $@.
+# Until https://issues.apache.org/jira/browse/KAFKA-4307 is available, there are
+# inconsistencies in broker CLI parameters.  Some use --bootstrap-server, others
+# use --broker-list, so we have to support both for now.
+# --broker-list should be removed in later versions in favor of --bootstrap-server
+broker_list_commands="kafka-console-producer "\
+"kafka-consumer-perf-test "\
+"kafka-replay-log-producer "\
+"kafka-replica-verification "\
+"kafka-simple-consumer-shell "\
+"kafka-verifiable-consumer "\
+"kafka-verifiable-producer"
+
+bootstrap_server_commands="kafka-console-consumer "\
+"kafka-broker-api-versions "\
+"kafka-consumer-groups "
+
+zookeeper_commands="kafka-configs "\
+"kafka-consumer-offset-checker.sh "\
+"kafka-preferred-replica-election "\
+"kafka-reassign-partitions "\
+"kafka-replay-log-producer "\
+"kafka-topics"
+
+zookeeper_connect_commands="kafka-acls"
+
+EXTRA_OPTS=""
+echo "${broker_list_commands}" | /bin/grep -q "${command}" && EXTRA_OPTS="${BROKER_LIST_OPT} "
+echo "${bootstrap_server_commands}" | /bin/grep -q "${command}" && EXTRA_OPTS="${EXTRA_OPTS}${BOOTSTRAP_SERVER_OPT} "
+echo "${zookeeper_commands}" | /bin/grep -q "${command}" && EXTRA_OPTS="${EXTRA_OPTS}${ZOOKEEPER_OPT} "
+echo "${zookeeper_connect_commands}" | /bin/grep -q "${command}" && EXTRA_OPTS="${EXTRA_OPTS}${ZOOKEEPER_CONNECT_OPT} "
+
+# Print out the command we are about to exec, and then run it
+# set -f to not expand wildcards in command, e.g. --topic '*'
+set -f
+PS4=
+set -x
+${docker_exec} ${command} ${EXTRA_OPTS}$@

--- a/ksql/Dockerfile
+++ b/ksql/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:stretch
+
+# Faster debian mirror
+RUN sed -i -e 's|http://deb.debian.org|http://debian.anycast-test.mirrors.debian.org|' /etc/apt/sources.list
+RUN sed -i -e 's|http://security.debian.org|http://security.anycast-test.mirrors.debian.org/|' /etc/apt/sources.list
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    procps \
+    curl gnupg \
+    openjdk-8-jre-headless
+
+# Setup skroutz repositories
+ADD skroutz-stable.list /etc/apt/sources.list.d/
+ADD skroutz-pu.list /etc/apt/sources.list.d/
+RUN curl -sSL http://debian.skroutz.gr/skroutz.asc | apt-key add -
+
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    confluent-ksql
+
+ADD ksql-server.properties /etc/ksql/ksql-server.properties
+
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+EXPOSE 8088
+
+ENTRYPOINT ["/usr/bin/ksql-server-start", "/etc/ksql/ksql-server.properties"]

--- a/ksql/ksql-server.properties
+++ b/ksql/ksql-server.properties
@@ -1,0 +1,5 @@
+bootstrap.servers=kc1:9092,kc2:9092
+listeners=http://0.0.0.0:8088
+confluent.support.metrics.enable=false
+
+ksql.streams.auto.offset.reset=latest

--- a/ksql/skroutz-pu.list
+++ b/ksql/skroutz-pu.list
@@ -1,0 +1,1 @@
+deb http://debian.skroutz.gr/debian/  stretch-skroutz-proposed-updates main non-free

--- a/ksql/skroutz-stable.list
+++ b/ksql/skroutz-stable.list
@@ -1,0 +1,1 @@
+deb http://debian.skroutz.gr/debian/  stretch-skroutz main non-free


### PR DESCRIPTION
* Added all the confluent kafka-related services as optional containers. These are useful for local experimentation and development, that's how I got started with KSQL
* Add a helper script similar to the one we run on the Kafka brokers to be able to quickly type various Kafka CLI commands:
```sh
./k.sh topics --list
```
instead of
```sh
docker-compose exec kc1.docker kafka-topics --zookeeper zoo1,zoo2,zoo3 --list
```